### PR TITLE
Fix array restriction, at the expense of more updates

### DIFF
--- a/generated-docs/Data/Incremental/Array.md
+++ b/generated-docs/Data/Incremental/Array.md
@@ -65,8 +65,6 @@ map :: forall a b da db. Patch a da => Patch b db => (Jet a -> Jet b) -> Jet (IA
 
 Modify each array element by applying the specified function.
 
-_Note_: The function itself must not change over time.
-
 #### `mapWithIndex`
 
 ``` purescript
@@ -75,8 +73,6 @@ mapWithIndex :: forall a da b db. Patch a da => Patch b db => (Jet (Atomic Int) 
 
 Modify each array element by applying the specified function, taking the
 index of each element into account.
-
-_Note_: The function itself must not change over time.
 
 _Note_: Insertions or removals in the middle of an array will result
 in a cascade of modifications to the tail of the result.

--- a/generated-docs/Data/Incremental/Array.md
+++ b/generated-docs/Data/Incremental/Array.md
@@ -60,15 +60,18 @@ Compute the length of the array incrementally.
 #### `map`
 
 ``` purescript
-map :: forall a b da db. Patch a da => Patch b db => (Jet a -> Jet b) -> Jet (IArray a) -> Jet (IArray b)
+map :: forall a b da db. Patch a da => Patch b db => Eq db => (Jet a -> Jet b) -> Jet (IArray a) -> Jet (IArray b)
 ```
 
 Modify each array element by applying the specified function.
 
+_Note_: the `Eq` constraint is necessary in order to remove unnecessary nil
+changes in the result.
+
 #### `mapWithIndex`
 
 ``` purescript
-mapWithIndex :: forall a da b db. Patch a da => Patch b db => (Jet (Atomic Int) -> Jet a -> Jet b) -> Jet (IArray a) -> Jet (IArray b)
+mapWithIndex :: forall a da b db. Patch a da => Patch b db => Eq db => (Jet (Atomic Int) -> Jet a -> Jet b) -> Jet (IArray a) -> Jet (IArray b)
 ```
 
 Modify each array element by applying the specified function, taking the

--- a/src/Data/Incremental/Array.purs
+++ b/src/Data/Incremental/Array.purs
@@ -103,8 +103,6 @@ length { position, velocity } =
     go len _ = len
 
 -- | Modify each array element by applying the specified function.
--- |
--- | _Note_: The function itself must not change over time.
 map
   :: forall a b da db
    . Patch a da
@@ -114,7 +112,7 @@ map
   -> Jet (IArray b)
 map f { position: IArray xs, velocity: dxs } =
     { position: IArray (Prelude.map f0 xs)
-    , velocity: toChange (Array.catMaybes (mapAccumL go xs (fromChange dxs)).value)
+    , velocity: toChange ((Array.mapWithIndex (\i a -> ModifyAt i (fromChange (f (constant a)).velocity)) xs) <> Array.catMaybes (mapAccumL go xs (fromChange dxs)).value)
     }
   where
     f0 = _.position <<< f <<< constant
@@ -172,8 +170,6 @@ withIndex { position, velocity } =
 
 -- | Modify each array element by applying the specified function, taking the
 -- | index of each element into account.
--- |
--- | _Note_: The function itself must not change over time.
 -- |
 -- | _Note_: Insertions or removals in the middle of an array will result
 -- | in a cascade of modifications to the tail of the result.

--- a/src/Data/Incremental/Array.purs
+++ b/src/Data/Incremental/Array.purs
@@ -103,20 +103,37 @@ length { position, velocity } =
     go len _ = len
 
 -- | Modify each array element by applying the specified function.
+-- |
+-- | _Note_: the `Eq` constraint is necessary in order to remove unnecessary nil
+-- | changes in the result.
 map
   :: forall a b da db
    . Patch a da
   => Patch b db
+  => Eq db
   => (Jet a -> Jet b)
   -> Jet (IArray a)
   -> Jet (IArray b)
 map f { position: IArray xs, velocity: dxs } =
     { position: IArray (Prelude.map f0 xs)
-    , velocity: toChange ((Array.mapWithIndex (\i a -> ModifyAt i (fromChange (f (constant a)).velocity)) xs) <> Array.catMaybes (mapAccumL go xs (fromChange dxs)).value)
+    , velocity: toChange (f_updates <> xs_updates)
     }
   where
     f0 = _.position <<< f <<< constant
     f1 position velocity = (f { position, velocity }).velocity
+
+    -- Changes originating from changes in f
+    f_updates :: Array (ArrayChange b db)
+    f_updates =
+        Array.filter nonTrivial
+          (Array.mapWithIndex (\i a -> ModifyAt i (fromChange (f (constant a)).velocity)) xs)
+      where
+        nonTrivial (ModifyAt _ db) | db == mempty = false
+        nonTrivial _ = true
+
+    -- Changes originating from changes in xs
+    xs_updates :: Array (ArrayChange b db)
+    xs_updates = Array.catMaybes (mapAccumL go xs (fromChange dxs)).value
 
     go :: Array a -> ArrayChange a da -> { accum :: Array a, value :: Maybe (ArrayChange b db) }
     go xs_ (InsertAt i a) =
@@ -177,6 +194,7 @@ mapWithIndex
   :: forall a da b db
    . Patch a da
   => Patch b db
+  => Eq db
   => (Jet (Atomic Int) -> Jet a -> Jet b)
   -> Jet (IArray a)
   -> Jet (IArray b)

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -4,6 +4,7 @@ import Prelude
 
 import Control.Monad.Eff (Eff)
 import Data.Incremental (Jet, constant, fromChange, patch)
+import Data.Incremental.Array (IArray(..))
 import Data.Incremental.Array as IArray
 import Data.Incremental.Eq (Atomic(..), mapAtomic, replace)
 import Data.Incremental.Map as IMap
@@ -141,3 +142,10 @@ main = do
     , Tuple (Atomic 2) (Atomic 2)
     , Tuple (Atomic 4) (Atomic 5)
     ]
+
+  let t13 = (\x -> IArray.map \_ -> x)
+              { position: Atomic 1
+              , velocity: replace 2
+              } (constant (IArray [Atomic unit]))
+  assert $ unwrap t13.position == [Atomic 1]
+  assert $ fromChange t13.velocity == fromChange (IArray.modifyAt 0 (replace 2))


### PR DESCRIPTION
This removes the restriction on the `IArray.map` function's argument, but it comes at the cost of adding as many updates to the output as there are elements in the input, most of which are likely to be nil updates.

Perhaps this could be mitigated by adding a method to the `Patch` class which would detect nil patches.