### PR TITLE
Fix for 0.13

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "purescript-tuples": "^5.0.0",
     "purescript-these": "^4.0.0",
-    "purescript-typelevel-prelude": "^3.0.0",
+    "purescript-typelevel-prelude": "^5.0.0",
     "purescript-enums": "^4.0.0",
     "purescript-filterable": "^3.0.0",
     "purescript-record": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "devDependencies": {
     "pulp": "^12.3.0",
     "purescript-psa": "^0.5.0",
-    "purescript": "^0.12.0",
+    "purescript": "^0.13.0",
     "rimraf": "^2.5.4"
   }
 }

--- a/src/Data/Incremental/Record.purs
+++ b/src/Data/Incremental/Record.purs
@@ -15,7 +15,7 @@ import Prelude
 import Data.Incremental (class Patch, Change, Jet, fromChange, patch, toChange)
 import Data.Newtype (class Newtype, unwrap, wrap)
 import Data.Symbol (class IsSymbol, SProxy(..))
-import Type.Row (class RowToList, Cons, Nil, RLProxy(..), kind RowList)
+import Type.RowList (class RowToList, Cons, Nil, RLProxy(..), kind RowList)
 import Record as Record
 import Prim.Row as Row
 


### PR DESCRIPTION
Changes import to `Type.RowList`, and bumps some version numbers.

These changes are all thats needed to compile against the `psc-0.13.0-20190602` package set.